### PR TITLE
remove unnecessary minor and patch version spec from devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "author": "nakano-masaki@arkedgespace.com",
   "license": "MIT",
   "devDependencies": {
-    "npm-run-all": "^4.1.5",
-    "prettier": "^3.0.3",
-    "renovate": "^37.0.0"
+    "npm-run-all": "^4",
+    "prettier": "^3",
+    "renovate": "^37"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 devDependencies:
   npm-run-all:
-    specifier: ^4.1.5
+    specifier: ^4
     version: 4.1.5
   prettier:
-    specifier: ^3.0.3
-    version: 3.0.3
+    specifier: ^3
+    version: 3.1.1
   renovate:
-    specifier: ^37.0.0
+    specifier: ^37
     version: 37.105.3(typanion@3.14.0)
 
 packages:
@@ -4592,12 +4592,6 @@ packages:
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
-    dev: true
-
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
-    engines: {node: '>=14'}
-    hasBin: true
     dev: true
 
   /prettier@3.1.1:


### PR DESCRIPTION
`package.json`のバージョン指定から不要なminor,patchバージョンの指定を削除します。prettier、npm-run-allは本体の動作に影響を与えない補助的なツールに過ぎず、renovate（に含まれる`renovate-config-validator`）コマンドについても、minorまでバージョンを管理する必要性が薄いことからこのようにします。