### PR TITLE
【Config migration】`regexManager` -> `customManager`

### DIFF
--- a/earthfile.json5
+++ b/earthfile.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  regexManagers: [
+  customManagers: [
     {
       customType: "regex",
       fileMatch: ["Earthfile"],

--- a/rust-toolchain.json5
+++ b/rust-toolchain.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  regexManagers: [
+  customManagers: [
     {
       customType: "regex",
       fileMatch: ["^rust-toolchain(\\.toml)?$"],


### PR DESCRIPTION
`regexManagers`ではなく`customManagers`が現在の推奨の設定なので、そちらにマイグレーションを行います。

#11 とは独立です。