### PR TITLE
Update fileMatch regex for rust-toolchain

### DIFF
--- a/rust-toolchain.json5
+++ b/rust-toolchain.json5
@@ -3,7 +3,7 @@
   customManagers: [
     {
       customType: "regex",
-      fileMatch: ["^rust-toolchain(\\.toml)?$"],
+      fileMatch: ["(^|/)rust-toolchain(\\.toml)?$"],
       matchStrings: ['channel\\s*=\\s*"(?<currentValue>\\d+\\.\\d+\\.\\d+)"'],
       depNameTemplate: "rust",
       packageNameTemplate: "rust-lang/rust",


### PR DESCRIPTION
To support cases where it's placed in subdirectories within a monorepo, not just at the repository root.