### PR TITLE
add helpers:pinGitHubActionDigests to default config

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":timezone(Asia/Tokyo)",
     ":enableVulnerabilityAlerts",
+    "helpers:pinGitHubActionDigests",
     "github>arkedge/renovate-config:earthfile.json5",
     "github>arkedge/renovate-config:cargo-chef-docker.json5",
     "github>arkedge/renovate-config:rust-toolchain.json5",


### PR DESCRIPTION
github actions を tag ではなく、commit hash で指定するようにします。
実体としては、以下の package rule です
```
{
  "packageRules": [
    {
      "matchDepTypes": [
        "action"
      ],
      "pinDigests": true
    }
  ]
}
```