### PR TITLE
add minimumReleaseAge option in renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,7 @@
     "github>arkedge/renovate-config:cargo-chef-docker.json5",
     "github>arkedge/renovate-config:rust-toolchain.json5",
     "github>arkedge/renovate-config:trust-self-hosted-action-versioning.json5",
-    "github>arkedge/renovate-config:group-self-hosted-monorepo.json5"
+    "github>arkedge/renovate-config:group-self-hosted-monorepo.json5",
+    "github>arkedge/renovate-config:npm-minimumReleaseAge.json5"
   ]
 }

--- a/npm-minimumReleaseAge.json5
+++ b/npm-minimumReleaseAge.json5
@@ -1,0 +1,9 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      matchDatasources: ["npm"],
+      minimumReleaseAge: "7 days",
+    },
+  ],
+}


### PR DESCRIPTION
# 概要

npmのサプライチェーンアタックに対応として、npmから7日間新しいpackageの受け入れを遅延させます。